### PR TITLE
Fix a bug in read book

### DIFF
--- a/service/bookCrudService.js
+++ b/service/bookCrudService.js
@@ -103,8 +103,8 @@ exports.createBook = (book) => {
   });
 };
 
-exports.readBooks = () => {
-  return bookDao.readBooks(db);
+exports.readBooks = (bookId = "%") => {
+  return bookDao.readBooks(db, bookId);
 };
 
 exports.updateBook = (book) => {


### PR DESCRIPTION
It was always returning all books even when a book ID was specified. Bug was likely the result of bad resolution of merge conflicts.